### PR TITLE
Add zero-width support for SoSnowy and IceCold

### DIFF
--- a/v2/script.js
+++ b/v2/script.js
@@ -88,7 +88,7 @@ Chat = {
                     Chat.info.emotes[emote.code] = {
                         id: emote.id,
                         image: 'https://cdn.betterttv.net/emote/' + emote.id + '/3x',
-                        zeroWidth: ["5e76d338d6581c3724c0f0b2", "5e76d399d6581c3724c0f0b8"].includes(emote.id) // "5e76d338d6581c3724c0f0b2" => cvHazmat, "5e76d399d6581c3724c0f0b8" => cvMask
+                        zeroWidth: ["5e76d338d6581c3724c0f0b2", "5e76d399d6581c3724c0f0b8", "567b5b520e984428652809b6", "5849c9a4f52be01a7ee5f79d"].includes(emote.id) // "5e76d338d6581c3724c0f0b2" => cvHazmat, "5e76d399d6581c3724c0f0b8" => cvMask, "567b5b520e984428652809b6" => SoSnowy, "5849c9a4f52be01a7ee5f79d" => IceCold
                     };
                 });
             });


### PR DESCRIPTION
[SoSnowy](https://betterttv.com/emotes/567b5b520e984428652809b6) and [IceCold](https://betterttv.com/emotes/5849c9a4f52be01a7ee5f79d) are two seasonal BTTV emotes which are added around Christmas holidays. Wouldn't hurt having ZW support for them right away once they get enabled.