### PR TITLE
v2.3.5 - remove kraken v5, change to helix, requires oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 **jChat** is an overlay that allows you to show your Twitch chat on screen with OBS, XSplit, and any other streaming software that supports browser sources. It supports your [**BetterTTV**](https://betterttv.com/), [**FrankerFaceZ**](https://www.frankerfacez.com/) and [**7TV**](https://7tv.app/) emotes, always at the best available quality. You have many options to customize your chat, like enabling a smooth animation for new messages, or fading old ones after some time. If you have a chat full of !gamble addicts, you can choose to hide bots and commands messages. It also comes with many fonts and styling options that can be combined as desired.
 ### The app is up and running on the [**website**](https://www.giambaj.it/twitch/jchat/).
+
+**Local jChat** running jChat locally is supported.  Download the files and point to index.html in https://github.com/giambaJ/jChat/tree/main/v2 - a Twitch Helix API oauth code will be required in credentials.js. (fixme: how to efficiently get helix api oauth tokens)
+
 ## Features
 - 7TV, BTTV and FFZ emotes support
 - Custom channel badges
@@ -13,5 +16,3 @@
 - Hide bots messages (on/off)
 - Hide commands messages (on/off)
 - !refreshoverlay to make newly added emotes appear (mods only)
-
-**Local jChat** running jChat locally is supported.  Download the files and point to index.html in https://github.com/giambaJ/jChat/tree/main/v2 - a Twitch Helix API oauth code will be required in credentials.js. (fixme: how to efficiently get helix api oauth tokens)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ### The app is up and running on the [**website**](https://www.giambaj.it/twitch/jchat/).
 
 **Local jChat** running jChat locally is supported.  Download the files and point to index.html in https://github.com/giambaJ/jChat/tree/main/v2 - a Twitch Helix API oauth code will be required in credentials.js. (fixme: how to efficiently get helix api oauth tokens)
+* example: `file://v2/index.html?channel=yourusername&fade=10&hide_commands=true&size=1&shadow=0`
 
 ## Features
 - 7TV, BTTV and FFZ emotes support

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 **Local jChat** running jChat locally is supported.  Download the files and point to index.html in https://github.com/giambaJ/jChat/tree/main/v2 - a Twitch Helix API oauth code will be required in credentials.js. (fixme: how to efficiently get helix api oauth tokens)
 * example: `file://v2/index.html?channel=yourusername&fade=10&hide_commands=true&size=1&shadow=0`
+* credentials.js: `const credentials = 'YOUR_OAUTH_HERE';`
 
 ## Features
 - 7TV, BTTV and FFZ emotes support

--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@
 - Hide bots messages (on/off)
 - Hide commands messages (on/off)
 - !refreshoverlay to make newly added emotes appear (mods only)
+
+**Local jChat** running jChat locally is supported.  Download the files and point to index.html in https://github.com/giambaJ/jChat/tree/main/v2 - a Twitch Helix API oauth code will be required in credentials.js. (fixme: how to efficiently get helix api oauth tokens)

--- a/v2/credentials.js
+++ b/v2/credentials.js
@@ -1,0 +1,12 @@
+/* client_id is not required if running for your own chat.  client_id required for interacting with OTHER's chat */
+const client_id = 'YOUR_CLIENT_ID_CODE';
+const credentials = 'YOUR_OAUTH_CODE';
+// YOUR_USER_ID#
+
+/* references and how to get oauth codes for helix api
+https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/
+https://dev.twitch.tv/docs/authentication
+https://dev.twitch.tv/docs/api/reference
+*/
+
+/* helix oauth codes have a timelimit, 60 days, refreshing codes will be required */

--- a/v2/script.js
+++ b/v2/script.js
@@ -93,8 +93,10 @@ Chat = {
     },
 
     load: function(callback) {
-        TwitchAPI('https://api.twitch.tv/v5/users?login=' + Chat.info.channel).done(function(res) {
-            Chat.info.channelID = res.users[0]._id;
+/*        TwitchAPI('https://api.twitch.tv/helix/users?login=' + Chat.info.channel).done(function(res) {*/
+/* dont call helix again, the user_id is already stored*/
+        TwitchAPI().done(function(res) {
+            Chat.info.channelID = res.user_id;
             Chat.loadEmotes(Chat.info.channelID);
 
             // Load CSS
@@ -174,7 +176,9 @@ Chat = {
             }
 
             // Load cheers images
-            TwitchAPI("https://api.twitch.tv/v5/bits/actions?channel_id=" + Chat.info.channelId).done(function(res) {
+/*            TwitchAPI("https://api.twitch.tv/v5/bits/actions?channel_id=" + Chat.info.channelId).done(function(res) {*/
+/* untested change to user_id, i dont have ability to test cheer emotes on helix api*/
+            TwitchAPI().done(function(res) {
                 res.actions.forEach(action => {
                     Chat.info.cheers[action.prefix] = {}
                     action.tiers.forEach(tier => {

--- a/v2/utils.js
+++ b/v2/utils.js
@@ -19,5 +19,18 @@ function escapeHtml(message) {
 }
 
 function TwitchAPI(url) {
-    return $.getJSON(url + (url.search(/\?/) > -1 ? '&' : '?') + 'client_id=' + client_id);
+/*    return $.getJSON(url + (url.search(/\?/) > -1 ? '&' : '?') + 'client_id=' + client_id);*/
+/* use only helix api oauth endpoint to get user_id and store the id# */
+    return $.ajax({
+        type: "GET", 
+        url: "https://id.twitch.tv/oauth2/validate", 
+        dataType: "json",
+        headers: {'Authorization': 'Bearer ' + credentials},
+/* not required client_id auth for running locally */
+/*        headers: {'Client-Id': client_id},*/
+        success : function(result) { 
+            //set your variable to the result
+            console.log('jChat: helix json aquired user_id');
+        }
+    });
 }


### PR DESCRIPTION
this is a working stop gap for running jchat locally.  has nothing to do with using giamba's website url
using giamba's website url currently working because his site offers different scripts than posted here
he is using his own oauth backend to interact with Helix API
waiting version 3 to be updated here

credentials.js required
const credentials = 'YOUR_OAUTH_CODE';
is required to get user_id#

this is only required to view OTHER users's chat.  not for yourself, you are the bearer and you only need to provide the bearer oauth to gain `user_id`
`const client_id =`
again client_id is only required when getting information about ***other*** users

noted information added for running local jChat
getting helix api oauth tokens - help wanted (url or otherwise)

some notes left in the code for future editing